### PR TITLE
Add support for ruby-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,8 @@ Quick fix for Rubocop warnings
 
 ## Requirements
 
+Either of:
+
+- [Ruby LSP \- Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
 - [Ruby Solargraph \- Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=castwide.solargraph)
+

--- a/package.json
+++ b/package.json
@@ -43,7 +43,5 @@
     "typescript": "^4.1.3",
     "vscode-test": "^1.5.0"
   },
-  "extensionDependencies": [
-    "castwide.solargraph"
-  ]
+  "extensionDependencies": []
 }

--- a/src/QuickFixProvider.ts
+++ b/src/QuickFixProvider.ts
@@ -80,7 +80,7 @@ export const provideCodeActions = (
 ): CodeAction[] => {
   const diagnostics = context.diagnostics.filter(
     (diagnostic) =>
-      diagnostic.source === 'rubocop' &&
+      (diagnostic.source === 'rubocop' || diagnostic.source === 'RuboCop') &&
       FIXABLE_SEVERITIES.includes(diagnostic.severity)
   );
   return diagnostics.length > 0 ? createFix(document, diagnostics) : [];


### PR DESCRIPTION
Adds actions to the diagnostics created by https://github.com/Shopify/ruby-lsp

See also:
https://github.com/Shopify/ruby-lsp/pull/1114