### PR TITLE
handle diagnostics where the "code" field is an object

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/example"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"

--- a/example/.rubocop.yml
+++ b/example/.rubocop.yml
@@ -1,0 +1,9 @@
+AllCops:
+  NewCops: enable
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Naming/MethodParameterName:
+  AllowedNames:
+    - ex
+    - id
+    - ctx

--- a/example/.vscode/extensions.json
+++ b/example/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "castwide.solargraph",
+    "shopify.ruby-lsp",
+  ],
+  "unwantedRecommendations": []
+}

--- a/example/.vscode/settings.json
+++ b/example/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  
+  "solargraph.checkGemVersion": false,
+  "solargraph.useBundler": true,
+  "rubyLsp.formatter": "rubocop",
+
+  // false to test only ruby-lsp
+  "solargraph.diagnostics": true,
+  "rubyLsp.enabledFeatures": {
+    // false to test only solargraph
+    "diagnostics": true,
+  }
+}

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "solargraph"
+gem "rubocop"

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,0 +1,74 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    backport (1.2.0)
+    base64 (0.1.1)
+    benchmark (0.2.1)
+    diff-lcs (1.5.0)
+    e2mmap (0.1.0)
+    jaro_winkler (1.5.6)
+    json (2.6.3)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    language_server-protocol (3.17.0.3)
+    nokogiri (1.15.4-x86_64-darwin)
+      racc (~> 1.4)
+    parallel (1.23.0)
+    parser (3.2.2.4)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.1)
+    rainbow (3.1.1)
+    rbs (2.8.4)
+    regexp_parser (2.8.2)
+    reverse_markdown (2.1.1)
+      nokogiri
+    rexml (3.2.6)
+    rubocop (1.57.1)
+      base64 (~> 0.1.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    solargraph (0.49.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      rbs (~> 2.0)
+      reverse_markdown (~> 2.0)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
+    thor (1.3.0)
+    tilt (2.3.0)
+    unicode-display_width (2.5.0)
+    yard (0.9.34)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  rubocop
+  solargraph
+
+BUNDLED WITH
+   2.4.10

--- a/example/testfile.rb
+++ b/example/testfile.rb
@@ -1,0 +1,13 @@
+a = "1"
+b = "2"
+
+c = "adsfads\"adsfasdf"
+
+adsfadf = '1'
+adsf =  'a'  + '' ;
+
+a = { :a => 1, b: 2 }
+
+def thing(a)
+  asdfasdf
+end


### PR DESCRIPTION
fixes #4 

- Handle diagnostics where the "code" field is an object
- If we can't figure out the name of the rule, don't provide a code action
- Add a little example for manually testing

ESLint caused a bit of diff noise, apologies!